### PR TITLE
Add OS Specific ignores to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,82 @@
-# Binaries for programs and plugins
+# Golang - https://github.com/github/gitignore/blob/master/Go.gitignore
+## Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
 
-# Test binary, build with `go test -c`
+## Test binary, build with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+## Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# macOS - https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
+## General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+## Icon must end with two \r
+Icon
+
+
+## Thumbnails
+._*
+
+## Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+## Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Linux - https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
+*~
+
+## temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+## KDE directory preferences
+.directory
+
+## Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+## .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Windows - https://github.com/github/gitignore/blob/master/Global/Windows.gitignore
+## Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+## Dump file
+*.stackdump
+
+## Folder config file
+[Dd]esktop.ini
+
+## Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+## Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+## Windows shortcuts
+*.lnk


### PR DESCRIPTION
Add attribution to the gitignore source directives and ensure to have OS specific ignores, so that this can be developed on any platform without picking up undesired files.